### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ypushkala/internship-day-2/security/code-scanning/2](https://github.com/ypushkala/internship-day-2/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow uses the `github-tag-action` to create tags, it requires `contents: write` permission. This ensures the workflow has only the necessary access to perform its tasks and no more.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
